### PR TITLE
Fix mobile pagination scroll to top

### DIFF
--- a/client/src/hooks/use-pagination-scroll.ts
+++ b/client/src/hooks/use-pagination-scroll.ts
@@ -1,0 +1,36 @@
+import { useRef, useCallback } from 'react';
+import { scrollToElement } from '@/lib/utils';
+
+interface UsePaginationScrollOptions {
+  headerOffset?: number;
+  delay?: number;
+}
+
+export function usePaginationScroll(options?: UsePaginationScrollOptions) {
+  const containerRef = useRef<HTMLElement>(null);
+  
+  const scrollToContainer = useCallback(() => {
+    scrollToElement(containerRef.current, {
+      headerOffset: options?.headerOffset,
+      delay: options?.delay,
+    });
+  }, [options?.headerOffset, options?.delay]);
+
+  const handlePageChange = useCallback((
+    page: number,
+    setCurrentPage: (page: number) => void,
+    updateURL?: (params: { page: number }) => void
+  ) => {
+    setCurrentPage(page);
+    if (updateURL) {
+      updateURL({ page });
+    }
+    scrollToContainer();
+  }, [scrollToContainer]);
+
+  return {
+    containerRef,
+    scrollToContainer,
+    handlePageChange,
+  };
+}

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,6 +1,55 @@
-import { clsx, type ClassValue } from "clsx"
+import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+// Utility function for smooth scrolling with mobile optimization
+export function scrollToElement(element: HTMLElement | null, options?: {
+  headerOffset?: number;
+  delay?: number;
+  behavior?: 'smooth' | 'instant';
+  mobileHeaderOffset?: number;
+}) {
+  const {
+    headerOffset = 80, // Default offset for sticky header
+    mobileHeaderOffset, // Additional offset for mobile if needed
+    delay = 100, // Default delay to ensure content is rendered
+    behavior = 'smooth'
+  } = options || {};
+
+  if (!element) return;
+
+  setTimeout(() => {
+    // Double-check element still exists and is visible
+    if (!element || !element.offsetParent) return;
+    
+    const elementTop = element.offsetTop;
+    
+    // Use mobile-specific offset if provided and on mobile
+    const isMobile = window.innerWidth < 768; // md breakpoint
+    const actualOffset = isMobile && mobileHeaderOffset !== undefined 
+      ? mobileHeaderOffset 
+      : headerOffset;
+    
+    const scrollPosition = Math.max(0, elementTop - actualOffset);
+    
+    // Use smooth scroll with fallback for better mobile compatibility
+    if (behavior === 'smooth' && 'scrollBehavior' in document.documentElement.style) {
+      window.scrollTo({
+        top: scrollPosition,
+        behavior: 'smooth'
+      });
+    } else {
+      // Fallback for older browsers/devices or instant scroll
+      window.scrollTo(0, scrollPosition);
+    }
+  }, delay);
+}
+
+// Utility to detect if device is mobile
+export function isMobileDevice(): boolean {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || 
+         window.innerWidth < 768;
 }

--- a/client/src/pages/news.tsx
+++ b/client/src/pages/news.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Pagination } from "@/components/ui/pagination";
 import { useTitle } from "@/hooks/use-title";
 import { useState, useRef } from "react";
+import { scrollToElement } from "@/lib/utils";
 import type { News } from "@shared/schema";
 
 interface NewsResponse {
@@ -177,10 +178,13 @@ function AllNewsList() {
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
-    // Scroll to the top of the AllNewsList component
-    if (sectionRef.current) {
-      sectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
+    
+    // Scroll to the top of the AllNewsList component with mobile optimization
+    scrollToElement(sectionRef.current, {
+      headerOffset: 80, // Desktop offset
+      mobileHeaderOffset: 100, // Extra offset for mobile to account for mobile action buttons
+      delay: 150 // Slightly longer delay for mobile
+    });
   };
 
   if (isLoading) {

--- a/client/src/pages/products.tsx
+++ b/client/src/pages/products.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useState, useRef, useEffect } from "react";
 import { useLocation, useRoute } from "wouter";
-import { Filter, Grid, List } from "lucide-react";
+import { Search, Grid, List, Filter } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -12,6 +12,8 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/co
 import { Pagination, ItemsPerPageSelector, PaginationInfo } from "@/components/ui/pagination";
 import { useTitle } from "@/hooks/use-title";
 import type { Product, Category } from "@shared/schema";
+import { FilterSidebar } from "@/components/product/filter-sidebar";
+import { scrollToElement } from "@/lib/utils";
 
 export default function Products() {
   const [location, setLocation] = useLocation();
@@ -175,10 +177,13 @@ export default function Products() {
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
     updateURL({ page });
-    // Scroll to the top of the products section
-    if (productsRef.current) {
-      productsRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
+    
+    // Scroll to the top of the products section with mobile optimization
+    scrollToElement(productsRef.current, {
+      headerOffset: 80, // Desktop offset
+      mobileHeaderOffset: 100, // Extra offset for mobile to account for mobile action buttons
+      delay: 150 // Slightly longer delay for mobile
+    });
   };
 
   const handleItemsPerPageChange = (items: number) => {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement a new scroll utility to fix incorrect pagination scroll behavior on mobile devices.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
On mobile, navigating to the next page did not consistently scroll the view back to the top of the pagination component, often being obscured by sticky headers or mobile action buttons. This PR introduces a `scrollToElement` utility that accounts for different header offsets on desktop and mobile, and includes a slight delay to ensure content is rendered before scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-0539b16a-ddba-4e7d-b13a-f96a4b76a6f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0539b16a-ddba-4e7d-b13a-f96a4b76a6f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>